### PR TITLE
Fix connection config

### DIFF
--- a/kanban-backend/db.js
+++ b/kanban-backend/db.js
@@ -1,6 +1,3 @@
-import { Pool } from 'pg';
-import config from './db/config.js';
-
-const pool = new Pool(config);
+import pool from './db/config.js';
 
 export default pool;

--- a/kanban-backend/db/config.js
+++ b/kanban-backend/db/config.js
@@ -1,7 +1,12 @@
-export default {
+import pkg from 'pg';
+const { Pool } = pkg;
+
+const pool = new Pool({
   user: 'postgres',
   host: 'localhost',
   database: 'kanban',
   password: 'postgres',
-  port: 5432
-};
+  port: 5432,
+});
+
+export default pool;


### PR DESCRIPTION
## Summary
- expose pg Pool directly from backend config

## Testing
- `npm test` in `kanban-backend` *(fails: no test specified)*
- `npm test` in `kanban-frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68887edcce9c8323a8f582a764e14a29