### PR TITLE
Add API route for board columns and server test endpoint

### DIFF
--- a/kanban-backend/index.js
+++ b/kanban-backend/index.js
@@ -1,7 +1,6 @@
 import express from 'express';
 import cors from 'cors';
-import bodyParser from 'body-parser';
-import pool from './db.js';
+import pool from './db/config.js';
 import boardsRouter from './routes/boards.js';
 import columnsRouter from './routes/columns.js';
 import tasksRouter from './routes/tasks.js';
@@ -9,7 +8,12 @@ import tasksRouter from './routes/tasks.js';
 const app = express();
 
 app.use(cors());
-app.use(bodyParser.json());
+app.use(express.json());
+
+// Тестовый маршрут для проверки сервера
+app.get('/', (req, res) => {
+  res.send('Kanban backend is running');
+});
 
 app.use('/boards', boardsRouter);
 app.use('/columns', columnsRouter);
@@ -34,4 +38,30 @@ app.get('/api/board/:id', async (req, res) => {
   }
 });
 
-app.listen(3000, () => console.log('Backend running on port 3000'));
+// API для получения данных доски
+app.get('/api/columns/board/:boardId', async (req, res) => {
+  try {
+    const { boardId } = req.params;
+
+    const columns = await pool.query(
+      'SELECT * FROM columns WHERE board_id = $1 ORDER BY position',
+      [boardId]
+    );
+
+    const tasks = await pool.query(
+      'SELECT * FROM tasks WHERE column_id IN (SELECT id FROM columns WHERE board_id = $1)',
+      [boardId]
+    );
+
+    res.json({
+      columns: columns.rows,
+      tasks: tasks.rows
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+const PORT = 3000;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- update backend server setup to use express.json
- add root server test route
- add `/api/columns/board/:boardId` route returning columns and tasks
- expose PORT variable for server start

## Testing
- `npm run dev` *(fails: manual check shows server starts)*
- `node index.js`
- `curl http://localhost:3000/`
- `curl http://localhost:3000/api/columns/board/1`
